### PR TITLE
Wire up EnvResolver in node-cli, pass through to root via Opts struct

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -23,11 +23,11 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"github.com/virtual-kubelet/node-cli/internal/commands/providers"
-	"github.com/virtual-kubelet/node-cli/internal/commands/root"
-	"github.com/virtual-kubelet/node-cli/internal/commands/version"
-	"github.com/virtual-kubelet/node-cli/opts"
-	"github.com/virtual-kubelet/node-cli/provider"
+	"github.com/elotl/node-cli/internal/commands/providers"
+	"github.com/elotl/node-cli/internal/commands/root"
+	"github.com/elotl/node-cli/internal/commands/version"
+	"github.com/elotl/node-cli/opts"
+	"github.com/elotl/node-cli/provider"
 )
 
 // Option sets an option on the command.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/virtual-kubelet/node-cli
+module github.com/elotl/node-cli
 
 go 1.12
 

--- a/go.sum
+++ b/go.sum
@@ -200,6 +200,7 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/virtual-kubelet/virtual-kubelet v1.0.0 h1:zR1JNFWVtwk1NTzO97+5Lf1Vgxv7l3GCZgzAIvA2X/0=
 github.com/virtual-kubelet/virtual-kubelet v1.0.0/go.mod h1:U/LQr7vG/vQ3BnnPGaHQST7igDltJ7Jrg5kR6VdUIgk=
+github.com/virtual-kubelet/virtual-kubelet v1.2.1 h1:VvURva/YxqizYd2Humk1RmEhrrYrmU07NHNanrtarxI=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=

--- a/internal/commands/providers/provider.go
+++ b/internal/commands/providers/provider.go
@@ -19,7 +19,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/virtual-kubelet/node-cli/provider"
+	"github.com/elotl/node-cli/provider"
 )
 
 // NewCommand creates a new providers subcommand

--- a/internal/commands/root/flag.go
+++ b/internal/commands/root/flag.go
@@ -19,7 +19,7 @@ import (
 	"os"
 
 	"github.com/spf13/pflag"
-	"github.com/virtual-kubelet/node-cli/opts"
+	"github.com/elotl/node-cli/opts"
 	"k8s.io/klog"
 )
 

--- a/internal/commands/root/http.go
+++ b/internal/commands/root/http.go
@@ -24,8 +24,8 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
-	"github.com/virtual-kubelet/node-cli/opts"
-	"github.com/virtual-kubelet/node-cli/provider"
+	"github.com/elotl/node-cli/opts"
+	"github.com/elotl/node-cli/provider"
 	"github.com/virtual-kubelet/virtual-kubelet/log"
 	"github.com/virtual-kubelet/virtual-kubelet/node/api"
 )

--- a/internal/commands/root/node.go
+++ b/internal/commands/root/node.go
@@ -18,8 +18,8 @@ import (
 	"context"
 	"strings"
 
-	"github.com/virtual-kubelet/node-cli/opts"
-	"github.com/virtual-kubelet/node-cli/provider"
+	"github.com/elotl/node-cli/opts"
+	"github.com/elotl/node-cli/provider"
 	"github.com/virtual-kubelet/virtual-kubelet/errdefs"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"

--- a/internal/commands/root/root.go
+++ b/internal/commands/root/root.go
@@ -196,6 +196,7 @@ func runRootCommandWithProviderAndClient(ctx context.Context, pInit provider.Ini
 		SecretInformer:    secretInformer,
 		ConfigMapInformer: configMapInformer,
 		ServiceInformer:   serviceInformer,
+		EnvResolver:       c.EnvResolver,
 	})
 	if err != nil {
 		return errors.Wrap(err, "error setting up pod controller")

--- a/internal/commands/root/root.go
+++ b/internal/commands/root/root.go
@@ -22,9 +22,9 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/virtual-kubelet/node-cli/manager"
-	"github.com/virtual-kubelet/node-cli/opts"
-	"github.com/virtual-kubelet/node-cli/provider"
+	"github.com/elotl/node-cli/manager"
+	"github.com/elotl/node-cli/opts"
+	"github.com/elotl/node-cli/provider"
 	"github.com/virtual-kubelet/virtual-kubelet/errdefs"
 	"github.com/virtual-kubelet/virtual-kubelet/log"
 	"github.com/virtual-kubelet/virtual-kubelet/node"

--- a/internal/commands/root/root_test.go
+++ b/internal/commands/root/root_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/virtual-kubelet/node-cli/opts"
-	"github.com/virtual-kubelet/node-cli/provider"
-	"github.com/virtual-kubelet/node-cli/provider/mock"
+	"github.com/elotl/node-cli/opts"
+	"github.com/elotl/node-cli/provider"
+	"github.com/elotl/node-cli/provider/mock"
 	"gotest.tools/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/opencensus/init.go
+++ b/opencensus/init.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/virtual-kubelet/node-cli/opts"
+	"github.com/elotl/node-cli/opts"
 	"github.com/virtual-kubelet/virtual-kubelet/errdefs"
 	"github.com/virtual-kubelet/virtual-kubelet/log"
 	"go.opencensus.io/trace"

--- a/opts/opts.go
+++ b/opts/opts.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
+	"github.com/virtual-kubelet/virtual-kubelet/node/env"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -88,6 +89,8 @@ type Opts struct {
 	KubeAPIBurst int32
 
 	Version string
+
+	EnvResolver env.ResolverFunc
 }
 
 // FromEnv sets default options for unset values on the passed in option struct.

--- a/provider/store.go
+++ b/provider/store.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"sync"
 
-	"github.com/virtual-kubelet/node-cli/manager"
+	"github.com/elotl/node-cli/manager"
 )
 
 // Store is used for registering/fetching providers


### PR DESCRIPTION
This is a small change that allows us to keep using node-cli while passing objects and arguments through to the root command by putting those things in the `Opts` struct.

I realize `Opts` was only holding command line flags but I thought this was better than creating an additional `Config` structure that also gets passed through to the root command.

This will go alongside changes that are going into virtual-kubelet.  I think we can move kip over to our own version of node-cli.  I will hold off on using this fork in kip until the env var change lands in virtual-kubelet.