### PR TITLE
Wait for informers

### DIFF
--- a/internal/commands/root/root.go
+++ b/internal/commands/root/root.go
@@ -20,11 +20,11 @@ import (
 	"path"
 	"time"
 
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
 	"github.com/elotl/node-cli/manager"
 	"github.com/elotl/node-cli/opts"
 	"github.com/elotl/node-cli/provider"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 	"github.com/virtual-kubelet/virtual-kubelet/errdefs"
 	"github.com/virtual-kubelet/virtual-kubelet/log"
 	"github.com/virtual-kubelet/virtual-kubelet/node"
@@ -120,7 +120,9 @@ func runRootCommandWithProviderAndClient(ctx context.Context, pInit provider.Ini
 	// Start the informers now, so the provider will get a functional resource
 	// manager.
 	podInformerFactory.Start(ctx.Done())
+	podInformerFactory.WaitForCacheSync(ctx.Done())
 	scmInformerFactory.Start(ctx.Done())
+	scmInformerFactory.WaitForCacheSync(ctx.Done())
 
 	apiConfig, err := getAPIConfig(c)
 	if err != nil {


### PR DESCRIPTION
In runRootCommandWithProviderAndClient(), the pod and scm informers are
started before calling the provider init function. However, Start() is
asynchronous, since it calls informer.Run() via a goroutine. Thus there
is still a race condition, where the provider might get a
ResourceManager that is non-functional.

I added a WaitForCacheSync() call for both informers to ensure they are
operational before calling the provider init function.